### PR TITLE
chore: add frozen lockfile to actions

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -23,7 +23,7 @@ jobs:
       with:
           version: 8
     - name: Install Dependencies
-      run: pnpm i                  
+      run: pnpm i --frozen-lockfile        
     - name: Cypress.io
       uses: cypress-io/github-action@v6.7.8
       with:
@@ -50,7 +50,7 @@ jobs:
       with:
           version: 8
     - name: Install Dependencies
-      run: pnpm i                  
+      run: pnpm i --frozen-lockfile             
     - name: Cypress.io
       uses: cypress-io/github-action@v6.7.8
       with:

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -19,9 +19,9 @@ jobs:
       with:
         node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
     - name: Setup pnpm
-      uses: pnpm/action-setup@v3.0.0
+      uses: pnpm/action-setup@v4
       with:
-          version: 8
+          version: 9.0.2
     - name: Install Dependencies
       run: pnpm i --frozen-lockfile        
     - name: Cypress.io
@@ -46,9 +46,9 @@ jobs:
       with:
         node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
     - name: Setup pnpm
-      uses: pnpm/action-setup@v3.0.0
+      uses: pnpm/action-setup@v4
       with:
-          version: 8
+          version: 9.0.2
     - name: Install Dependencies
       run: pnpm i --frozen-lockfile             
     - name: Cypress.io

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       with:
           version: 8
     - name: Install Dependencies
-      run: pnpm i
+      run: pnpm i --frozen-lockfile
     - name: Test
       run: pnpm test
   lint:
@@ -44,6 +44,6 @@ jobs:
       with:
           version: 8
     - name: Install Dependencies
-      run: pnpm i
+      run: pnpm i --frozen-lockfile
     - name: Lint
       run: pnpm lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,9 +19,9 @@ jobs:
       with:
         node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
     - name: Setup pnpm
-      uses: pnpm/action-setup@v3.0.0
+      uses: pnpm/action-setup@v4
       with:
-          version: 8
+          version: 9.0.2
     - name: Install Dependencies
       run: pnpm i --frozen-lockfile
     - name: Test
@@ -40,9 +40,9 @@ jobs:
       with:
         node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
     - name: Setup pnpm
-      uses: pnpm/action-setup@v3.0.0
+      uses: pnpm/action-setup@v4
       with:
-          version: 8
+          version: 9.0.2
     - name: Install Dependencies
       run: pnpm i --frozen-lockfile
     - name: Lint


### PR DESCRIPTION
Adding --frozen-lockfile tag to install so error can be populated from gh actions and not only vercel.